### PR TITLE
fix: add sleep to crontab.entry before launching foundry

### DIFF
--- a/scripts/auto_pull/crontab.entry
+++ b/scripts/auto_pull/crontab.entry
@@ -1,1 +1,1 @@
-@reboot sh $ORCS_SYSTEM_PATH/scripts/auto_pull/auto_pull.sh
+@reboot sleep 60 && sh $ORCS_SYSTEM_PATH/scripts/auto_pull/auto_pull.sh


### PR DESCRIPTION
let system finish startup, otherwise foundry may fail to launch